### PR TITLE
lint signal_.py closes #147

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -86,10 +86,10 @@ def query_end(con):
 
 
 # TODO: file_list can be removed from the constructor all together. create_book can get it from self.files
-class Book(playlist.Playlist, signal_.Signal_):
+class Book(playlist.Playlist, signal_.Signal):
     def __init__(self, path, file_list, config, files, book_reader):
         playlist.Playlist.__init__(self)
-        signal_.Signal_.__init__(self)
+        signal_.Signal.__init__(self)
         self.index = None
         self.playlist_data = PlaylistData(title='New Book', path=path)
         self.config = config
@@ -510,7 +510,7 @@ class Book_C:
         self.index = None
 
         # instantiate the component_views observable and the component view controllers
-        self.component_views = signal_.Signal_()
+        self.component_views = signal_.Signal()
         # register the signals
         [self.component_views.add_signal(handle) for handle in book_view_interface.api_]
 

--- a/src/book_ease.py
+++ b/src/book_ease.py
@@ -705,11 +705,11 @@ class BookReader_:
             self.close_book(books_index)
 
 
-class Files_(signal_.Signal_):
+class Files_(signal_.Signal):
     """class to manage the file management features of book_ease"""
 
     def __init__(self, config):
-        signal_.Signal_.__init__(self)
+        signal_.Signal.__init__(self)
         self.config = config
         self.library_path = self.config['app']['library path']
         self.current_path = self.library_path

--- a/src/gui/gtk/BookView.py
+++ b/src/gui/gtk/BookView.py
@@ -277,7 +277,7 @@ class Book_View(Gtk.Box):
 
     def __init__(self, book_, book_reader):
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0)
-        self.signal = signal_.Signal_()
+        self.signal = signal_.Signal()
         self.signal.add_signal('pinned_state_changed')
         self.book = book_
         self.notebook = self.book.book_reader.book_reader_view.book_reader_notebook

--- a/src/gui/gtk/pinned_books_view.py
+++ b/src/gui/gtk/pinned_books_view.py
@@ -121,7 +121,7 @@ class PinnedButton_VC(book_view_interface.BookView_Interface):
         self.book = book
         self.view = PinnedButton_V()
         self.view.pinned_button.connect('toggled', self.on_button_toggled)
-        self.signal_ = signal_.Signal_()
+        self.signal_ = signal_.Signal()
         self.signal_.add_signal('toggled')
         self.signal_.add_signal('book_updated')
 

--- a/src/pinned_books.py
+++ b/src/pinned_books.py
@@ -26,7 +26,7 @@ import sqlite_tables
 import singleton_
 
 
-class PinnedBooks_C(signal_.Signal_):
+class PinnedBooks_C(signal_.Signal):
     """
     controller for the pinned books module
     """
@@ -35,7 +35,7 @@ class PinnedBooks_C(signal_.Signal_):
         """
         instantiate both the PinnedBooks_V and the PinnedBooks_M
         """
-        signal_.Signal_.__init__(self)
+        signal_.Signal.__init__(self)
         self.add_signal('open-book')
         self.model = PinnedBooks_M()
         self.view = PinnedBooks_V(self.model.get_col_info(), self)
@@ -242,7 +242,7 @@ class PinnedButton_M:
         raise ValueError('button not found in pinned_button_list')
 
 
-class PinnedBooks_M(signal_.Signal_):
+class PinnedBooks_M(signal_.Signal):
     """
     maintain the list of pinned books
     this includes saving/retrieving the list to/from premenant storage
@@ -250,7 +250,7 @@ class PinnedBooks_M(signal_.Signal_):
     """
 
     def __init__(self):
-        signal_.Signal_.__init__(self)
+        signal_.Signal.__init__(self)
         # signal that that something in the pinned list might have changed
         self.add_signal('pinned_list_changed')
         # the database interface

--- a/src/signal_.py
+++ b/src/signal_.py
@@ -21,11 +21,15 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 """
-helper class to implement signal system (notifications)
+helper module to implement signal system (notifications)
 note: instantiated/inherited by server
 """
 
-class Signal_():
+class Signal():
+    """
+    helper class to implement signal system (notifications)
+    note: instantiated/inherited by server
+    """
 
     def __init__(self):
         """
@@ -78,4 +82,5 @@ class Signal_():
         signal[1]: cb_args
         signal[2]: cb_kwargs
         """
-        [signal[0](*signal[1], *extra_args, **signal[2], **extra_kwargs) for signal in self._sig_handlers[handle]]
+        for signal in self._sig_handlers[handle]:
+            signal[0](*signal[1], *extra_args, **signal[2], **extra_kwargs)


### PR DESCRIPTION
refactored signal_.Signal_ to signal.Signal because PascalCase. Name
conflicts aren't an issue anymore with the class inside of its own
module

change signal.Signal.signal to use for loop instead of list
comprehension, since the generated list isn't being used anyway

added class docstrings to signal_.Signal