### PR TITLE
lint book_view_interface.py closes #149

### DIFF
--- a/src/book_view_interface.py
+++ b/src/book_view_interface.py
@@ -20,19 +20,23 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
-import abc
-from gi.repository import Gtk, Gdk, GLib
-from pathlib import Path
-
-
 """module wide gtk.builder instance"""
-__book_builder = None
+
+import abc
+from pathlib import Path
+from gi.repository import Gtk
+
+
+__book_builder = None # pylint: disable=invalid-name
+
 
 
 def get_builder() ->'Gtk.builder':
     """instantiate and return module wide gtk.builder instance"""
+
     glade_path = Path().cwd() / 'gui' / 'gtk' / 'book.glade'
-    global __book_builder
+    global __book_builder# pylint: disable=global-statement disable=invalid-name
+
     if __book_builder is None:
         __book_builder = Gtk.Builder()
         __book_builder.add_from_file(str(glade_path))
@@ -45,7 +49,8 @@ api_ = {'update':lambda x:x.update,
         'begin_display_mode':lambda x:x.begin_display_mode}
 
 
-class BookView_Interface(metaclass=abc.ABCMeta):
+class BookViewInterface(metaclass=abc.ABCMeta):
+    """interface to implement the observer/observable interface used by the Book_C"""
 
     @classmethod
     def __subclasshook__(cls, subclass):
@@ -67,21 +72,21 @@ class BookView_Interface(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def begin_edit_mode():
+    def begin_edit_mode(self):
         """switch to editing mode"""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def begin_display_mode():
+    def begin_display_mode(self):
         """switch to display mode"""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def close():
+    def close(self):
         """cleanup and close the gui"""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_view():
+    def get_view(self):
         """retrieve the view from the VI classes"""
         raise NotImplementedError

--- a/src/gui/gtk/BookView.py
+++ b/src/gui/gtk/BookView.py
@@ -766,7 +766,7 @@ class Book_V:
         self.pinned_v_box.destroy()
 
 
-class Book_VC(book_view_interface.BookView_Interface):
+class Book_VC(book_view_interface.BookViewInterface):
     """
     Book_VC is a controller for Book_V
     """
@@ -802,7 +802,7 @@ class Title_V:
         self.title_entry = builder.get_object('title_entry')
 
 
-class Title_VC(book_view_interface.BookView_Interface):
+class Title_VC(book_view_interface.BookViewInterface):
 
     def __init__(self, book_):
         self.book = book_
@@ -844,7 +844,7 @@ class ControlBtn_V:
         self.edit_button = builder.get_object('edit_button')
 
 
-class ControlBtn_VC(book_view_interface.BookView_Interface):
+class ControlBtn_VC(book_view_interface.BookViewInterface):
 
     def __init__(self, book_):
         self.book = book_
@@ -936,7 +936,7 @@ class  Playlist_V:
         self.playlist_view.destroy()
 
 
-class Playlist_VC(book_view_interface.BookView_Interface):
+class Playlist_VC(book_view_interface.BookViewInterface):
     """Controller for the treeview that displays a playlist"""
 
     def __init__(self, book_):

--- a/src/gui/gtk/pinned_books_view.py
+++ b/src/gui/gtk/pinned_books_view.py
@@ -115,7 +115,7 @@ class PinnedButton_V():
         self.pinned_button = builder.get_object('pinned_button')
 
 
-class PinnedButton_VC(book_view_interface.BookView_Interface):
+class PinnedButton_VC(book_view_interface.BookViewInterface):
 
     def __init__(self, book):
         self.book = book


### PR DESCRIPTION
refactor book_view_interface.BookView_Interface to
book_view_interface.BookViewInterface. This touched BookView.py and
pinned_books_view.py

added class docstrings to BookViewInterface

disabled pylint warnings for invalid-name, pylint incorrectly thought
module variable __book_builder was constant

disabled pylint warnings for global-statement. This is actualy what I
want and pylint needs to quiet down about it.