### PR TITLE
Delete temporary lines that were never meant to be committed.

### DIFF
--- a/src/player.py
+++ b/src/player.py
@@ -165,9 +165,6 @@ class GstPlayer:
     # disabled because GStreamer callbacks automatically supply args that are unused.
 
     def __init__(self):
-        # delete this
-        self.once = False
-
         Gst.init(None)
         self.playback_state = None
         self.position = None


### PR DESCRIPTION
The undesired lines look like this:
`# delete this`
`self.once = False`
` `

affects:
player.GstPlayer.__init__