### PR TITLE
Create FileList and FileMgrC classes. move Gtk.Listsstore to file_mgr…

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import re
 import os
+from pathlib import Path
 import mutagen
 import playlist
 import signal_
@@ -297,7 +298,7 @@ class PlaylistDBI():
         playlists = []
         with abt.DB_CONNECTION.query() as con:
             # execute query
-            pl_list = abt.Playlist.get_rows_by_path(con, pl_data.get_path())
+            pl_list = abt.Playlist.get_rows_by_path(con, str(pl_data.get_path().absolute()))
         # build playlists list
         for plst in pl_list:
             play_list = PlaylistData(title=plst['title'], path=plst['path'], id_=plst['id'])

--- a/src/book_ease.py
+++ b/src/book_ease.py
@@ -25,6 +25,7 @@
 import os
 import re
 import logging
+from pathlib import Path
 import gi
 gi.require_version("Gtk", "3.0")  # pylint: disable=wrong-import-position
 from gi.repository import Gtk, GdkPixbuf, Gdk
@@ -256,7 +257,7 @@ class BookMark:
             Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, "Select", Gtk.ResponseType.OK
         )
         dialog.set_default_size(800, 400)
-        dialog.set_current_folder(self.file_mgr.get_path_current())
+        dialog.set_current_folder(str(self.file_mgr.get_cwd()))
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
             target = dialog.get_filename()
@@ -316,7 +317,7 @@ class BookMark:
                     tree_iter = model.get_iter(path)
                     value = model.get_value(tree_iter, self.column_map['target']['g_col'])
                     tvs.unselect_all()
-                    self.file_mgr.cd(value)
+                    self.file_mgr.cd(Path(value))
 
     def on_button_press(self, _: Gtk.TreeView, event: Gdk.EventButton) -> None:
         """
@@ -573,23 +574,20 @@ class MainWindow(Gtk.Window):
             # show file manager pane
             self.file_manager_pane.show()
 
-
 #pylint: disable=unused-variable
 def main(unused_args):
     """entry point for book_ease"""
     builder = Gtk.Builder()
     builder.add_from_file("book_ease.glade")
-    # files backend
-    file_mgr_0 = file_mgr.FileMgr()
-    # left side file viewer
-    file_mgr_view_0 = file_mgr_view.FileMgrView(builder.get_object("files_1"), file_mgr_0)
+    # file manager system
+    file_mgr_c_0 = file_mgr.FileMgrC(builder, file_mgr_view_name="files_1")
     # left side bookmarks
-    book_mark_0 = BookMark(builder.get_object("bookmarks_1"), file_mgr_view_0, file_mgr_0)
+    book_mark_0 = BookMark(builder.get_object("bookmarks_1"), file_mgr_c_0.file_mgr_view, file_mgr_c_0.file_mgr)
     # image pane
-    image_view_ref = Image_View(file_mgr_0, builder)
+    image_view_ref = Image_View(file_mgr_c_0.file_mgr, builder)
 
     # bookreader backend
-    book_reader_ref = book_reader.BookReader(file_mgr_0, builder)
+    book_reader_ref = book_reader.BookReader(file_mgr_c_0.file_mgr, builder)
 
     player_c_ref = player.PlayerC(book_reader_ref, builder)
 

--- a/src/file_mgr.py
+++ b/src/file_mgr.py
@@ -28,199 +28,180 @@ It supports the following basic features:
 Copy, Move, Delete, Rename
 """
 
+from __future__ import annotations
 import re
 import os
 from datetime import datetime
 from pathlib import Path
 from typing import Literal
+from typing import List
+from typing import TYPE_CHECKING
+from typing_extensions import Self
 import gi
-gi.require_version("Gtk", "3.0")  # pylint: disable=wrong-import-position
-from gi.repository import Gtk
-from gi.repository.GdkPixbuf import Pixbuf
 import book_ease_tables
 import signal_
+from gui.gtk import file_mgr_view
+if TYPE_CHECKING:
+    gi.require_version("Gtk", "3.0")  # pylint: disable=wrong-import-position
+    from gi.repository import Gtk
+
+
+class FileList:
+    """Wrapper for os.DirEntry objects created by os.scandir()"""
+
+    def __init__(self, parent_dir: Path) -> None:
+        if not parent_dir.is_dir():
+            raise ValueError("dir_path must be a directory.")
+        self.parent_dir = parent_dir
+
+    class FileListIterator:
+        """Iterate outer FileList and provide access to each file's attributes"""
+        dot_file_regex = re.compile(r"^[\.]")
+
+        def __init__(self, outer) -> None:
+            self.outer = outer
+            self.files = os.scandir(outer.parent_dir)
+            self._cur_file = None
+
+        def __next__(self) -> Self:
+            self._cur_file = next(self.files)
+            return self
+
+        @property
+        def path(self) -> Path:
+            """get the file refered to by self as a pathlib.Path object"""
+            return Path(self._cur_file)
+
+        @property
+        def name(self) -> str:
+            """get the name of the file refered to by self as a string"""
+            return self._cur_file.name
+
+        @property
+        def timestamp_formatted(self) -> str:
+            """Get a formatted timestamp as a string"""
+            return datetime.fromtimestamp(self._cur_file.stat().st_ctime).strftime("%y/%m/%d  %H:%M")
+
+        @property
+        def size_formatted(self) -> tuple[str, Literal['b', 'kb', 'mb', 'gb', 'tb']]:
+            """
+            convert file size to string with appropriate units
+            This includes generating a units suffix thats returned with the formatted size as a tuple.
+            """
+            units = 'b'
+            size = self._cur_file.stat().st_size
+            length = len(f"{size:.0f}")
+            if length <= 3:
+                val = str(size)
+            elif length <= 6:
+                val = f"{size / 10e+2:.1f}"
+                units = 'kb'
+            elif length <= 9:
+                val = f"{size / 10e+5:.1f}"
+                units = 'mb'
+            elif length <= 12:
+                val = f"{size / 10e+8:.1f}"
+                units = 'gb'
+            else:
+                val = f"{size / 10e+11:.1f}"
+                units = 'tb'
+            return (val, units)
+
+        def is_file(self) -> bool:
+            """Determine if self refers to an actual file"""
+            return self._cur_file.is_file()
+
+        def is_dir(self) -> bool:
+            """Determine if self refers to a directory"""
+            return self._cur_file.is_dir()
+
+        def is_hidden_file(self) -> bool:
+            """determine if the file refered to by self is a hidden file"""
+            if self.dot_file_regex.match(self._cur_file.name):
+                return True
+            return False
+
+    def __iter__(self) -> FileListIterator:
+        return self.FileListIterator(self)
+
 
 class FileMgr(signal_.Signal):
     """class to manage the file management features of book_ease"""
-    default_library_path = str(Path.home())
+    _default_library_path = Path.home()
 
     def __init__(self) -> None:
         signal_.Signal.__init__(self)
-        file_mgr_dbi = FileMgrDBI()
-        self.current_path: str = file_mgr_dbi.get_library_path() or self.default_library_path
-        self.path_back_max_len = 10
-        self.path_ahead_max_len = 10
-        self.path_back = []
-        self.path_ahead = []
+        self._file_mgr_dbi = FileMgrDBI()
+        self._current_path: Path = self._file_mgr_dbi.get_library_path() or self._default_library_path
+        self._path_back_max_len = 10
+        self._path_ahead_max_len = 10
+        self._path_back: List[Path] = []
+        self._path_ahead = []
         self.show_hidden_files = False
         self.sort_ignore_case = True
         self.sort_dir_first = True
-
-        self.file_list = self.get_file_list_new()
-        self.icon_pos, self.f_name_pos, self.is_dir_pos, self.f_size_pos, self.f_units_pos, self.ctime_pos \
-            = (0, 1, 2, 3, 4, 5)
-
         # Signals
         # Notify of file changes
         self.add_signal('cwd_changed')
-        # populate the file_list
-        self.__update_file_list()
 
-    def __update_file_list(self) -> None:
-        """repopulate the files list gtk model with the files in cwd"""
-        self.file_list.clear()
-        self.populate_file_list(self.file_list, self.current_path)
-        # notify subscribers that the file list has been updated
-        self.send('cwd_changed')
-
-    def get_file_list_new(self) -> Gtk.ListStore:
-        """create a new file list model for the files view"""
-        f_list = Gtk.ListStore(Pixbuf, str, bool, str, str, str)
-        return f_list
-
-    def populate_file_list(self, file_list: Gtk.ListStore, path: str) -> None:
-        """Determine if files in path, directory, are suitable to be displayed and add them to the file_list"""
-        files = os.scandir(path)
-        # populate liststore
-        for i in files:
-            # ignore things like broken symlinks
-            if not i.is_file() and not i.is_dir():
-                continue
-            # user option
-            if not self.show_hidden_files and self.is_hidden_file(i.name):
-                continue
-            # format timestamp
-            timestamp_formatted = datetime.fromtimestamp(i.stat().st_ctime).strftime("%y/%m/%d  %H:%M")
-            # format file size and select correct units
-            size_f, units = self.format_f_size(i.stat().st_size)
-            # set correct icon
-            icon = Gtk.IconTheme.get_default().load_icon('multimedia-player', 24, 0)
-            if i.is_dir():
-                icon = Gtk.IconTheme.get_default().load_icon('folder', 24, 0)
-            # append to file list
-            file_list.append((icon, i.name, i.is_dir(), size_f, units, str(timestamp_formatted)))
-
-
-    def get_file_list(self) -> Gtk.ListStore:
+    def get_file_list(self) -> FileList:
         """retrieve self.file_list"""
-        return self.file_list
+        return FileList(self._current_path)
 
-    # callback signaled by Files_View
-    def cmp_f_list_dir_fst(self, model, row1, row2) -> Literal[1] | Literal[-1] | Literal[0]:
-        """
-        compare method for sorting sort columns in the file view
-        returns gt:1 lt:-1 or eq:0
-        """
-        sort_column, sort_order = model.get_sort_column_id()
-        name1 = model.get_value(row1, sort_column)
-        name2 = model.get_value(row2, sort_column)
-
-        if self.sort_ignore_case:
-            name1 = name1.lower()
-            name2 = name2.lower()
-
-        if self.sort_dir_first:
-            is_dir_1 = model.get_value(row1, 2)
-            is_dir_2 = model.get_value(row2, 2)
-            # account for the sort order when returning directories first
-            direction = 1
-            if sort_order is Gtk.SortType.DESCENDING:
-                direction = -1
-            #return immediately if comparing a dir and a file
-            if is_dir_1 and not is_dir_2:
-                return -1 * direction
-            if not is_dir_1 and is_dir_2:
-                return 1 * direction
-
-        if name1 < name2:
-            return -1
-        if name1 == name2:
-            return 0
-        return 1
-
-    def format_f_size(self, size) -> tuple[str, Literal['b', 'kb', 'mb', 'gb', 'tb']]:
-        """
-        convert filesize to string with appropriate units
-        This includes generating a units suffix thats returned with the formatted size as a tuple.
-        """
-        units = 'b'
-        length = len(f"{size:.0f}")
-        if length <= 3:
-            val = str(size)
-        elif length <= 6:
-            val = f"{size / 10e+2:.1f}"
-            units = 'kb'
-        elif length <= 9:
-            val = f"{size / 10e+5:.1f}"
-            units = 'mb'
-        elif length <= 12:
-            val = f"{size / 10e+8:.1f}"
-            units = 'gb'
-        else:
-            val = f"{size / 10e+11:.1f}"
-            units = 'tb'
-        return (val, units)
-
-    def append_to_path_back(self) -> None:
+    def _append_to_path_back(self) -> None:
         """track file change history"""
-        if len(self.path_back) >= self.path_back_max_len:
-            self.path_back.pop(0)
-        self.path_back.append(self.current_path)
+        if len(self._path_back) >= self._path_back_max_len:
+            self._path_back.pop(0)
+        self._path_back.append(self._current_path)
 
-    def append_to_path_ahead(self) -> None:
+    def _append_to_path_ahead(self) -> None:
         """track file change history"""
-        if len(self.path_ahead) >= self.path_ahead_max_len:
-            self.path_ahead.pop(0)
-        self.path_ahead.append(self.current_path)
+        if len(self._path_ahead) >= self._path_ahead_max_len:
+            self._path_ahead.pop(0)
+        self._path_ahead.append(self._current_path)
 
 
-    def get_path_current(self) -> str:
+    def get_cwd(self) -> Path:
         """get the current path"""
-        return self.current_path
+        return self._current_path
 
-    def cd(self, path: str) -> None:
+    def cd(self, path: Path) -> None:
         """move to a new working directory determined by path"""
-        if os.path.isdir(path):
-            self.append_to_path_back()
-            self.path_ahead.clear()
-            self.current_path = path
-            self.__update_file_list()
+        if path.is_dir():
+            self._append_to_path_back()
+            self._path_ahead.clear()
+            self._current_path = path
+            self.send('cwd_changed')
 
     def cd_ahead(self):
         """move forward to directory in the file change history"""
-        if len(self.path_ahead) > 0:
-            path = self.path_ahead.pop()
+        if len(self._path_ahead) > 0:
+            path = self._path_ahead.pop()
             if os.path.isdir(path):
-                self.append_to_path_back()
-                self.current_path = path
-                self.__update_file_list()
+                self._append_to_path_back()
+                self._current_path = path
+                self.send('cwd_changed')
             else:
-                self.path_ahead.append(path)
+                self._path_ahead.append(path)
 
     def cd_up(self, path: str) -> None:
         """move up one level in the directory tree"""
         if os.path.isdir(path):
-            self.append_to_path_back()
-            self.cd(os.path.split(self.get_path_current())[0])
-            self.__update_file_list()
+            self._append_to_path_back()
+            self.cd(self.get_cwd().parent)
+            #self.cd(os.path.split(self.get_cwd())[0])
+            self.send('cwd_changed')
 
     def cd_previous(self) -> None:
         """move back to directory in the file change history"""
-        if len(self.path_back) > 0:
-            path = self.path_back.pop()
-            if os.path.isdir(path):
-                self.append_to_path_ahead()
-                self.current_path = path
-                self.__update_file_list()
+        if len(self._path_back) > 0:
+            path = self._path_back.pop()
+            if path.is_dir():
+                self._append_to_path_ahead()
+                self._current_path = path
+                self.send('cwd_changed')
             else:
-                self.path_back.append(path)
-
-    def is_hidden_file(self, file_name: str) -> bool:
-        """determine if a file is a hidden file"""
-        valid = re.compile(r"^[\.]")
-        if valid.match(file_name):
-            return True
-        return False
+                self._path_back.append(path)
 
 
 class FileMgrDBI:
@@ -229,15 +210,21 @@ class FileMgrDBI:
     def __init__(self) -> None:
         self.settings_string = book_ease_tables.SettingsString()
 
-    def get_library_path(self) -> str | None:
+    def get_library_path(self) -> Path | None:
         """get the saved path to the root directory of the book library"""
         with book_ease_tables.DB_CONNECTION_MANAGER.query() as con:
             library_path_list = self.settings_string.get(con, 'Files', 'library_path')
-        return library_path_list[0]['value'] if library_path_list else None
+        return Path(library_path_list[0]['value']) if library_path_list else None
 
-    def set_library_path(self, library_path: str) -> None:
+    def set_library_path(self, library_path: Path) -> None:
         """
         Save the path to the root directory of the book library
         Not yet Implemented.
         """
-        pass
+
+
+class FileMgrC:
+    """Instantate the components of the file manager system."""
+    def __init__(self, builder: Gtk.Builder, file_mgr_view_name: str) -> None:
+        self.file_mgr = FileMgr()
+        self.file_mgr_view = file_mgr_view.FileMgrView(builder, file_mgr_view_name, self.file_mgr)


### PR DESCRIPTION
…_view.py #540 #543

file_mgr_view.py:
cleanup naming of private instance variables
move the file compare function to file_mgr_view
move the gtk.Liststore and its population to file_mgr_view

book.py:
PlaylistDBI changed to account for file paths being uniformly converted to pathlib.Path objects.

book_ease.py:
BookMark changed to account for file paths being uniformly converted to pathlib.Path objects. This includes importing pathlib.Path fix pylint unused variable warning in main()
update file manager system instantiation to use only FileManagerC

book_reader.py:
cleanup naming in BookReader to account for new FileMGgr class. convert NewBookOpener.has_new_media to use pathlib.Path.

file_mgr.py:
Create FileList class
remove methods from FileMgr that have had their functionality moved elsewhere. ie populate_file_list, get_file_list_new, etc. refacter FileMgr so private variables and methods are prefixed with underscore.
replace gtk.Liststore usage in FileMgr with new FileList class. account for conversion to pathlib.Path in FileMgrDBI. Create class FileMgrC