### PR TITLE
make the has_playlist combo box resizable close #556

### DIFF
--- a/src/gui/gtk/file_mgr.ui
+++ b/src/gui/gtk/file_mgr.ui
@@ -168,18 +168,6 @@
             <property name="can_focus">False</property>
             <property name="no_show_all">True</property>
             <child>
-              <object class="GtkComboBox" id="has_playlist_combo">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="hexpand">True</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkButton" id="open_playlist_btn">
                 <property name="label" translatable="yes">open</property>
                 <property name="visible">True</property>
@@ -188,6 +176,18 @@
               </object>
               <packing>
                 <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="has_playlist_combo">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>

--- a/src/gui/gtk/file_mgr_view.py
+++ b/src/gui/gtk/file_mgr_view.py
@@ -90,7 +90,10 @@ class PlaylistOpenerView:
         self.existing_playlist_opener_m = ExistingPlaylistOpenerM()
 
         self.has_playlist_combo.set_model(self.existing_playlist_opener_m.get_model())
+
         renderer_text = Gtk.CellRendererText()
+        renderer_text.set_property('width-chars', 10)
+        renderer_text.set_property('ellipsize', gi.repository.Pango.EllipsizeMode.END)
         self.has_playlist_combo.pack_start(renderer_text, True)
         self.has_playlist_combo.add_attribute(renderer_text, "text", ExistingPlaylistOpenerM.pl_title['g_col'])
 


### PR DESCRIPTION
file_mgr.ui:
Move the open button so that it is next to the create button instead of on the other side of the existing playlist combobox.

file_mgr.py:
set the width-chars (minimum width) porperty on the Gtk.CellRendererText that underlies the combo box.
This also requires setting the ellipsize property to gi.repository.Pango.EllipsizeMode.END