### PR TITLE
Create right-click context menu for the file manager system. #557

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 __pycache__/
 *.glade#
 *.glade~
+*.ui#
+*.ui~
 /testing/
 *.bak
 *.geany

--- a/src/book_ease.py
+++ b/src/book_ease.py
@@ -255,6 +255,9 @@ def main(unused_args):
     signal_.GLOBAL_TRANSMITTER.add_signal('open_book')
     signal_.GLOBAL_TRANSMITTER.add_signal('open_new_book')
     signal_.GLOBAL_TRANSMITTER.add_signal('book_updated')
+    # file_mgr
+    # Senders of 'dir_contents_updated' are expected to send the cwd as the extra_arg
+    signal_.GLOBAL_TRANSMITTER.add_signal('dir_contents_updated')
 
     builder = Gtk.Builder()
     builder.add_from_file("book_ease.glade")

--- a/src/gui/gtk/file_mgr_view_templates/delete_files_dialog.ui
+++ b/src/gui/gtk/file_mgr_view_templates/delete_files_dialog.ui
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="DeleteFilesDialog" parent="GtkDialog">
+    <property name="can_focus">False</property>
+    <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ok_btn">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Delete the following items?</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow" id="scrolled_window">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="margin_left">2</property>
+            <property name="margin_right">2</property>
+            <property name="shadow_type">in</property>
+            <property name="max_content_width">400</property>
+            <property name="max_content_height">400</property>
+            <property name="propagate_natural_width">True</property>
+            <property name="propagate_natural_height">True</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">4</property>
+                <property name="margin_right">4</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkBox" id="delete_items_box">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="move_to_trash">
+            <property name="label" translatable="yes">Move to Trash</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="active">True</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="recursive">
+            <property name="label" translatable="yes">Delete Directories Recursively</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="active">True</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">button1</action-widget>
+      <action-widget response="-5">ok_btn</action-widget>
+    </action-widgets>
+  </template>
+</interface>

--- a/src/gui/gtk/file_mgr_view_templates/error_dialog.ui
+++ b/src/gui/gtk/file_mgr_view_templates/error_dialog.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="ErrorDialog" parent="GtkMessageDialog">
+    <property name="can_focus">False</property>
+    <property name="type_hint">normal</property>
+    <property name="message_type">error</property>
+    <property name="text" translatable="yes">Failed to Delete the following files.</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="homogeneous">True</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="margin_left">2</property>
+            <property name="margin_right">2</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">4</property>
+                <property name="margin_right">4</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkBox" id="error_description_box">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-5">button1</action-widget>
+    </action-widgets>
+  </template>
+</interface>

--- a/src/gui/gtk/file_mgr_view_templates/file_mgr.ui
+++ b/src/gui/gtk/file_mgr_view_templates/file_mgr.ui
@@ -12,6 +12,90 @@
     <property name="can_focus">False</property>
     <property name="stock">gtk-go-forward</property>
   </object>
+  <object class="GtkImage" id="new_dir_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-directory</property>
+  </object>
+  <object class="GtkImage" id="rename_file_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-edit</property>
+  </object>
+  <object class="GtkMenu" id="ctrl_popup_menu">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkImageMenuItem" id="new_folder_menu_item">
+        <property name="label" translatable="yes">New Folder</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Create a new folder in the current directory.</property>
+        <property name="image">new_dir_image</property>
+        <property name="use_stock">False</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="copy_menu_item">
+        <property name="label">gtk-copy</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Copy the selected file to the clipboard.</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="paste_menu_item">
+        <property name="label">gtk-paste</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Paste a copied file.</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="cut_menu_item">
+        <property name="label">gtk-cut</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Copy the selected file to the clipboard,  deleting the original file once the copy has been pasted.</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="delete_menu_item">
+        <property name="label">gtk-delete</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Delete the selected file.</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="rename_menu_item">
+        <property name="label" translatable="yes">Rename</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Rename the selected file.</property>
+        <property name="image">rename_file_image</property>
+        <property name="use_stock">False</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="properties_menu_item">
+        <property name="label">gtk-properties</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Display the selected file's properties.</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">True</property>
+      </object>
+    </child>
+  </object>
   <object class="GtkImage" id="up">
     <property name="visible">True</property>
     <property name="can_focus">False</property>

--- a/src/gui/gtk/file_mgr_view_templates/file_mgr_view_templates.py
+++ b/src/gui/gtk/file_mgr_view_templates/file_mgr_view_templates.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+#
+#  file_mgr_view_dialogs.py
+#
+#  This file is part of book_ease.
+#
+#  Copyright 2021 mark cole <mark@capstonedistribution.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+"""
+This module contains all of the dialogs used by the file_mgr_view module.
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from pathlib import Path
+import gi
+gi.require_version("Gtk", "3.0")  # pylint: disable=wrong-import-position
+from gi.repository import Gtk
+if TYPE_CHECKING:
+    import file_mgr
+
+
+@Gtk.Template(filename='gui/gtk/file_mgr_view_templates/new_dir_dialog.ui')
+class NewDirDialog(Gtk.Dialog):
+    """Entry dialog to get the name of the new directory from the user."""
+    # pylint:disable=no-member
+    # pylint erroneously thinks that template members are of type Child.
+
+    __gtype_name__ = 'NewDirDialog'
+    _entry: Gtk.Entry = Gtk.Template.Child('entry')
+
+    class ResponseType:
+        """Named responses for the dialog buttons"""
+        AND_OPEN = 1
+
+    def get_entry_text(self) -> str:
+        """
+        Retrieve the new directory name as text from this dialog's
+        entry widget.
+        """
+        return self._entry.get_text()
+
+    def set_entry_text(self, text: str) -> None:
+        """Set the text in the new directory entry widget."""
+        self._entry.set_text(text)
+
+
+@Gtk.Template(filename='gui/gtk/file_mgr_view_templates/error_dialog.ui')
+class _ErrorDialog(Gtk.MessageDialog):
+    """
+    Error dialog to report which files failed to be manipulated.
+    Implements a Gtk.MessagDialog
+    """
+    __gtype_name__ = 'ErrorDialog'
+    error_description_box: Gtk.Box = Gtk.Template.Child('error_description_box')
+
+
+class ErrorDialog:
+    """
+    Error dialog to report which files failed to be manipulated.
+    Implements a Gtk.MessagDialog.
+    """
+    # pylint:disable=no-member
+    # pylint erroneously thinks that template members are of type Child.
+
+    def __init__(self, text: str, error_list: list[file_mgr.FileError]):
+        # Glade thinks that the default value for 'resizable' is True,
+        # so it doesn't include the flag in the .ui file unless it is False.
+        self._dialog = _ErrorDialog(resizable=True, message_type=Gtk.MessageType.ERROR, text=text)
+        self._add_error_list(error_list)
+        self._dialog.run()
+        self._dialog.destroy()
+
+    def _add_error_list(self, errors: list[file_mgr.FileError]):
+        """Add an error message to the dialog."""
+        for error in errors:
+            error_label = Gtk.Label(
+                'File: ' + str(error.file) + '\nError: ' + str(error.err), selectable=True
+            )
+            error_label.set_alignment(xalign=0, yalign=0.5)
+            self._dialog.error_description_box.pack_start(error_label, expand=False, fill=False, padding=6)
+        self._dialog.error_description_box.show_all()
+
+
+@Gtk.Template(filename='gui/gtk/file_mgr_view_templates/delete_files_dialog.ui')
+class DeleteFilesDialog(Gtk.Dialog):
+    """
+    Verify that the user wants to delete the selected files.
+    Determine of the user wants to delete the files or move them to the trash.
+    """
+    # pylint:disable=no-member
+    # pylint erroneously thinks that template members are of type Child.
+    __gtype_name__ = 'DeleteFilesDialog'
+    _move_to_trash: Gtk.CheckButton = Gtk.Template.Child('move_to_trash')
+    _recursive: Gtk.CheckButton = Gtk.Template.Child('recursive')
+    _delete_items_box: Gtk.Box = Gtk.Template.Child('delete_items_box')
+    _scrolled_window: Gtk.ScrolledWindow = Gtk.Template.Child('scrolled_window')
+
+    def add_files(self, *files: Path):
+        """Add files that are to be deleted to the dialog for user examination."""
+        for fil in files:
+            label = Gtk.Label(fil.name)
+            self._delete_items_box.pack_start(label, expand=False, fill=False, padding=2)
+            label.set_alignment(xalign=0, yalign=0.5)
+        self._delete_items_box.show_all()
+
+    @property
+    def trash(self) -> bool:
+        """Get the value of the move to trash check box."""
+        return self._move_to_trash.get_active()
+
+    @property
+    def recursive(self) -> bool:
+        """Return the value of the "recursive" check button."""
+        return self._recursive.get_active()
+
+
+@Gtk.Template(filename='gui/gtk/file_mgr_view_templates/file_mgr.ui')
+class FileManagerViewOuterT(Gtk.Box):
+    """The file manager view"""
+    __gtype_name__ = 'FileManagerViewOuter'
+    file_view_treeview_gtk: Gtk.TreeView = Gtk.Template.Child('file_view_treeview')
+    book_mark_treeview_gtk: Gtk.TreeView = Gtk.Template.Child('book_mark_treeview')
+    navigation_box: Gtk.Box = Gtk.Template.Child('navigation_box')
+    up_button: Gtk.Button = Gtk.Template.Child('up_button')
+    forward_button: Gtk.Button = Gtk.Template.Child('forward_button')
+    backward_button: Gtk.Button = Gtk.Template.Child('backward_button')
+    path_entry: Gtk.Entry = Gtk.Template.Child('path_entry')
+    has_playlist_combo: Gtk.ComboBox = Gtk.Template.Child('has_playlist_combo')
+    open_playlist_btn: Gtk.Button = Gtk.Template.Child('open_playlist_btn')
+    create_playlist_btn: Gtk.Button = Gtk.Template.Child('create_playlist_btn')
+    playlist_opener_box: Gtk.Button = Gtk.Template.Child('playlist_opener_box')
+    open_playlist_box: Gtk.Button = Gtk.Template.Child('open_playlist_box')
+
+    ctrl_popup_menu: Gtk.Menu = Gtk.Template.Child('ctrl_popup_menu')
+    new_folder_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('new_folder_menu_item')
+    copy_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('copy_menu_item')
+    paste_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('paste_menu_item')
+    cut_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('cut_menu_item')
+    delete_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('delete_menu_item')
+    rename_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('rename_menu_item')
+    properties_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('properties_menu_item')

--- a/src/gui/gtk/file_mgr_view_templates/new_dir_dialog.ui
+++ b/src/gui/gtk/file_mgr_view_templates/new_dir_dialog.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="open_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-open</property>
+  </object>
+  <template class="NewDirDialog" parent="GtkDialog">
+    <property name="can_focus">False</property>
+    <property name="type_hint">dialog</property>
+    <signal name="response" handler="on_response" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="cancel_btn">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_button_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ok_btn">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="open_btn">
+                <property name="label" translatable="yes">&amp; Open</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">open_image</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="entry">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="width_chars">0</property>
+            <property name="text" translatable="yes">Folder Name</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">cancel_btn</action-widget>
+      <action-widget response="-5">ok_btn</action-widget>
+      <action-widget response="1">open_btn</action-widget>
+    </action-widgets>
+  </template>
+</interface>


### PR DESCRIPTION
.gitignore:
exclude backup .ui glade files that end with ~ or #

book_ease.py:
Add global transmitter signal 'dir_contents_updated'

file_mgr.py:
Create FileError class to aid in propagating error info to the user. Add public methods FileMgr.mkdir and FileMgr.delete along with the private helpper methods.
Include the new templates file, file_mgr_view_templates.py.

file_manager.ui:
move file to file_mgr_view_templates directory
Add the right click popup menu with entries for the following file manager commands: New Folder, Delete, Copy, Paste, Cut, and Properties.

file_mgr_view.py:
move FileManagerViewOuterT to templates file: file_mgr_view_templates. Add the right click popup menu with functionality for the commands: New Folder and Delete.
The other events do have their callbacks connected. FileView handles the sensitivity of the control popup menu items depending n wether any files are selected in the gui.

delete_files_dialog.ui:
Create file

error_dialog.ui:
Create file

file_mgr_view_templates:
Create file.
contains template classes for all of the file manager system.

new_dir_dialog.py:
Create

file_navigation_control.ui:
Create file