### PR TITLE
add file rename functionality to the file manager system #557 #562

### DIFF
--- a/src/file_mgr.py
+++ b/src/file_mgr.py
@@ -245,6 +245,23 @@ class FileMgr():
             else:
                 self._path_back.append(path)
 
+    def rename(self, old_path: Path, new_path: Path) -> None | FileError:
+        """
+        Rename file from 'old_path' to 'new_path'.
+        """
+        try:
+            if new_path.exists():
+                raise FileExistsError('File already exists.')
+            old_path.rename(new_path)
+            signal_.GLOBAL_TRANSMITTER.send('dir_contents_updated', self._current_path)
+        except FileNotFoundError as e:
+            # Another process likely deleted the file during editing. Inform the
+            # user and the application that the directory contents have changed.
+            signal_.GLOBAL_TRANSMITTER.send('dir_contents_updated', self._current_path)
+            return FileError(new_path, e)
+        except FileExistsError as e:
+            return FileError(new_path, e)
+
     def mkdir(self, new_dir_abs_path: Path) -> None | FileError:
         """
         Create a new directory at the location described by new_dir_abs_path.


### PR DESCRIPTION
file_mgr.py:
Add method FileMgr.rename

file_mgr_view.py:
create a dict describing the properties of the menu_items of the control popup menu.
Set callbacks events pertinent to renaming the files: "edited", "editing-canceled", 'key-press-event'
connecting to:
on_rename_file_finished, on_rename_file_cancelled, and on_key_press resp.
Added method FileView._rename_selected_files
add F2 as hotkey to begin renaming process.