### PR TITLE
Add show_hidden_files and audio_files_only to the file manager system…

### DIFF
--- a/src/file_mgr.py
+++ b/src/file_mgr.py
@@ -102,7 +102,6 @@ class FileMgr():
         self._path_ahead_max_len = 10
         self._path_back: List[Path] = []
         self._path_ahead = []
-        self.show_hidden_files = False
         self.sort_ignore_case = True
         self.sort_dir_first = True
         # Signals

--- a/src/gui/gtk/file_mgr_view_templates/file_mgr.ui
+++ b/src/gui/gtk/file_mgr_view_templates/file_mgr.ui
@@ -95,6 +95,24 @@
         <property name="use_stock">True</property>
       </object>
     </child>
+    <child>
+      <object class="GtkCheckMenuItem" id="hidden_files_menu_item">
+        <property name="label">hidden files</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Show hidden files.</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkCheckMenuItem" id="audio_only_menu_item">
+        <property name="label">audio only</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Show only audio files.</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
   </object>
   <object class="GtkImage" id="up">
     <property name="visible">True</property>

--- a/src/gui/gtk/file_mgr_view_templates/file_mgr_view_templates.py
+++ b/src/gui/gtk/file_mgr_view_templates/file_mgr_view_templates.py
@@ -154,6 +154,8 @@ class FileManagerViewOuterT(Gtk.Box):
     delete_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('delete_menu_item')
     rename_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('rename_menu_item')
     properties_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('properties_menu_item')
+    hidden_files_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('hidden_files_menu_item')
+    audio_only_menu_item: Gtk.ImageMenuItem = Gtk.Template.Child('audio_only_menu_item')
 
 
 @Gtk.Template(filename='gui/gtk/file_mgr_view_templates/file_properties_dialog.ui')


### PR DESCRIPTION
…. #557 #562

file_mgr.py:
delete FileMgr.show_hidden_files flag, moved to FileView.

file_mgr_view.py:
*Add keybinding for ctrl-h to toggle show_hidden_files. *Add on_menu_item_toggled callback to handle the two new CheckMenuItems. *Modify populate_file_list to properly handle the show_hidden_files and show_audio_only flags when building the file list for display. *Fixes previously unknown bug, where the test for not-files wasn't actually working.

file_mgr.ui:
Add CheckMenuItem s for show_hidden_files and audio_files_only.

file_mgr_view_tempates.py:
Add references to FileManagerViewOuterT for the two CheckMenuItem s.