### PR TITLE
Implement cut, copy, paste operations close #557

### DIFF
--- a/src/file_mgr.py
+++ b/src/file_mgr.py
@@ -30,9 +30,11 @@ Copy, Move, Delete, Rename
 
 from __future__ import annotations
 import os
+import shutil
+import errno
 from pathlib import Path
-from shutil import rmtree
 from dataclasses import dataclass
+import threading
 from typing import List
 from typing import TYPE_CHECKING
 from typing_extensions import Self
@@ -47,6 +49,7 @@ from gui.gtk.file_mgr_view_templates import file_mgr_view_templates as fmvt
 # pylint: enable=no-name-in-module
 import book_mark
 from book_ease_path import BEPath
+import glib_utils
 if TYPE_CHECKING:
     gi.require_version("Gtk", "3.0")  # pylint: disable=wrong-import-position
     from gi.repository import Gtk
@@ -93,6 +96,7 @@ class FileError:
 class FileMgr():
     """class to manage the file management features of book_ease"""
     _default_library_path = Path.home()
+    _default_max_depth = 8
 
     def __init__(self) -> None:
         self.transmitter = signal_.Signal()
@@ -199,57 +203,229 @@ class FileMgr():
         except  FileExistsError as e:
             return FileError(new_dir_abs_path, e)
 
-    def delete(self, *files: Path | list[Path], move_to_trash=False, recursive=False) -> list[Path]:
+    def move(self,
+             src_file: Path,
+             dest_file: Path,
+             cancel_event: threading.Event | None = None) -> list[FileError]:
+        """
+        File move operation. Move source file to destination file.
+        """
+        error_list = []
+        if not src_file.exists():
+            error_list.append(FileError(src_file, "Source file does not exist!"))
+
+        if dest_file.exists():
+            error_list.append(FileError(src_file, f"Destination file already exists, {dest_file}"))
+
+        if not error_list:
+            try:
+                src_file.rename(dest_file)
+            except IOError as e:
+                if e.errno == errno.EXDEV:
+                    # errno.EXDEV == Cross-device link
+                    # perform the copy instead.
+                    copy_errs = self.copy(src_file, dest_file, cancel_event)
+                    error_list.extend(copy_errs)
+                    if not error_list:
+                        delete_errors = self.delete(src_file, cancel_event=cancel_event)
+                        error_list.extend(delete_errors)
+                else:
+                    error_list.append(FileError(src_file, e))
+        return error_list
+
+    def delete(self,
+               *files: Path | list[Path],
+               move_to_trash=False,
+               recursive=False,
+               cancel_event: threading.Event|None=None) -> list[Path]:
         """
         Delete files or send them to the trash.
         Returns a list of failed deletions.
+
+        threadsafe
         """
         if move_to_trash:
-            return self._trash(*files, recursive=recursive)
+            return self._trash(*files, recursive=recursive, cancel_event=cancel_event)
         else:
-            return self._delete(*files, recursive=recursive)
+            return self._delete(*files, recursive=recursive, cancel_event=cancel_event)
 
-    def _trash(self, *files: Path | list[Path], recursive=False) -> list[FileError]:
+    def copy(self,
+             src_file: Path,
+             dest_file: Path,
+             cancel_event: threading.Event|None=None,
+             depth: int=0) -> list[FileError]:
+        """
+        * Write the contents of src_file to dest_file.
+
+        * Threadsafe
+
+        * Note: All exceptions are caught and returned
+        """
+        # pylint: disable=broad-exception-caught
+        # Disabled because it doesn't matter why it failed, only that
+        # the failure can be reported to the user in the gui.
+        error_list = []
+        if cancel_event.is_set():
+            error_list.append(FileError(src_file, f"Failed to Copy to {dest_file}. Cancelled."))
+            return error_list
+
+        if depth >= self._default_max_depth:
+            error_list.append(FileError(src_file, f"Failed to copy to {dest_file} excedded max depth."))
+            return error_list
+
+        elif not src_file.exists():
+            error_list.append(FileError(src_file, "Source file does not exist!"))
+            return error_list
+
+        elif src_file.is_symlink():
+            # This needs to be before the test for is_dir because symlinks to
+            # directories also pass the test for is_dir.
+            try:
+                dest_file.symlink_to(src_file.readlink())
+            except Exception as e:
+                error_list.append(FileError(src_file, e))
+
+        elif src_file.is_dir():
+            if not dest_file.exists():
+                try:
+                    dest_file.mkdir()
+                    shutil.copystat(src_file, dest_file)
+                except Exception as e:
+                    error_list.append(FileError(src_file, e))
+
+            if dest_file.is_dir():
+                # Recursively copy the contents of src_file (directory) into dest_file (directory).
+                # testing for same names only matters if the calls from the view get more complex.
+                # Currently, the names are always the same.
+                if src_file.name == dest_file.name:
+                    for fil in os.listdir(src_file):
+                        new_src_file = Path(src_file, fil)
+                        new_dest_file = Path(dest_file, fil)
+                        error_list.extend(self.copy(new_src_file, new_dest_file, cancel_event, depth=depth+1))
+                else:
+                    # Call self.copy inside the dest_file directory.
+                    new_dest_file = Path(dest_file, src_file.name)
+                    error_list.extend(self.copy(src_file, new_dest_file, cancel_event, depth=depth+1))
+            else:
+                # dest_file exists and is not a directory.
+                error_list.append(FileError(src_file, f"Failed to copy to {dest_file}: Exists."))
+                return error_list
+
+        elif dest_file.exists():
+            # dest_file is not a directory and should not be overwritten.
+            error_list.append(FileError(src_file, f"Destination file already exists, {dest_file}"))
+            return error_list
+
+        elif src_file.is_fifo():
+            try:
+                os.mkfifo(dest_file)
+            except Exception as e:
+                error_list.append(FileError(src_file, e))
+
+        elif src_file.is_mount():
+            error_list.append(FileError(src_file, "File is a mount point."))
+            return error_list
+
+        elif src_file.is_file():
+            # Copy a regular file, while periodically checking for a cancellation event
+            # and preserving metadata.
+            try:
+                dest_file_temp = Path(dest_file.parent.absolute(), dest_file.name + '.part')
+                with open(src_file, 'rb') as i_put:
+                    with open(dest_file_temp, 'wb') as o_put:
+                        for byt in i_put:
+                            if cancel_event is None or not cancel_event.is_set():
+                                o_put.write(byt)
+                            else:
+                                raise glib_utils.AsyncWorkerCancelledError(f'Failed to Copy to {dest_file}. Cancelled.')
+                dest_file_temp.rename(dest_file)
+                shutil.copystat(src_file, dest_file)
+            except Exception as e:
+                error_list.append(FileError(src_file, e))
+        else:
+            error_list.append(FileError(dest_file, "Cannot copy files of this type."))
+
+        glib_utils.g_idle_add_once(signal_.GLOBAL_TRANSMITTER.send, 'dir_contents_updated', dest_file.parent)
+        return error_list
+
+    def _trash(self,
+               *files: Path | list[Path],
+               recursive=False,
+               cancel_event: threading.Event|None=None) -> list[FileError]:
         """
         Send files to the trash.
-        Send dir_contents_updated signal upon deletion of all files.
+        Send dir_contents_updated signal if any files were seccessfully trashed.
 
         Return a list of FileError describing any files that failed
         to be moved to the trash.
+
+        Threadsafe
         """
         failed_deletions = []
+        dir_changed = False
         for file in files:
+            if cancel_event.is_set():
+                failed_deletions.append(FileError(file, 'Delete File to Trash Cancelled.'))
+                continue
             try:
-                if file.is_dir() and not recursive and os.listdir():
+                if file.is_dir() and not recursive and os.listdir(file):
                     raise OSError(f"[Errno 39] Directory not empty: {file}")
                 fil: Gio.File  = Gio.File.new_for_path(str(file.absolute()))
                 fil.trash(None)
+                dir_changed = True
             except GLib.Error as e:
                 failed_deletions.append(FileError(file, e))
             except OSError as e:
                 failed_deletions.append(FileError(file, e))
-
-        signal_.GLOBAL_TRANSMITTER.send('dir_contents_updated', self._current_path)
+        if dir_changed:
+            glib_utils.g_idle_add_once(signal_.GLOBAL_TRANSMITTER.send, 'dir_contents_updated', self._current_path)
         return failed_deletions
 
-    def _delete(self, *files: Path | list[Path], recursive=False) -> list[Path]:
+    def _delete(self,
+                *files: Path | list[Path],
+                recursive=False,
+                cancel_event: threading.Event|None=None,
+                depth: int = 0) -> list[Path]:
         """
         Delete files
         Delete file recursively if one of the files is a directory and recursive is set to True.
             default: False
 
-        Send dir_contents_updated signal upon deletion of all files.
+        Send dir_contents_updated signal if any files were seccessfully deleted.
         Return a list of any files that failed to be deleted.
+
+        threadsafe
         """
         failed_deletions = []
+        if depth >= self._default_max_depth:
+            for file in files:
+                failed_deletions.append(FileError(file, 'Max Depth Reached.'))
+            return failed_deletions
+
         for file in files:
+            if cancel_event is not None and cancel_event.is_set():
+                failed_deletions.append(FileError(file, 'Delete File Cancelled.'))
+                continue
             try:
+                if not file.exists():
+                    failed_deletions.append(FileError(file, 'file: does not exist'))
+                    continue
+
                 if file.is_file():
                     file.unlink()
+
                 elif file.is_dir():
                     if recursive:
-                        rmtree(file)
-                    else:
+                        file_list_next = []
+                        for file_next in os.listdir(file):
+                            file_list_next.append(Path(file, file_next))
+
+                        if file_list_next:
+                            delete_errs = self._delete(*file_list_next,
+                                                       recursive=True,
+                                                       cancel_event=cancel_event,
+                                                       depth=depth+1)
+                            failed_deletions.extend(delete_errs)
                         file.rmdir()
             # pylint: disable=broad-exception-caught
             # Disabled because it doesn't matter why it failed, only that
@@ -257,7 +433,7 @@ class FileMgr():
             except Exception as e:
                 failed_deletions.append(FileError(file, e))
 
-        signal_.GLOBAL_TRANSMITTER.send('dir_contents_updated', self._current_path)
+        glib_utils.g_idle_add_once(signal_.GLOBAL_TRANSMITTER.send, 'dir_contents_updated', self._current_path)
         return failed_deletions
 
 


### PR DESCRIPTION
glib_utiils.py:
documentation cleanup.
Pass cb_kwargs to on_finished_callback.
FIX AsyncWorker.__init__ so all the target and callback args work smoothly for the passed in callback functions.
Add exception, AsyncWorkerCancelledError.

file_view.py:
Create FileMgrClipboard and FileMgrClipData with a global instance, file_view.file_mgr_clipboard.
Homogenize the naming of FileView's file operation callbacks. Implement cut, copy, paste operations
have FileView._delete_selected_files use the AsyncWorker.

file_mgr.py:
Add method FileMgr.move
make FileMgr.delete thread safe by handling a cancel event and using glib_utils.g_idle_add_once to notify of directory changed. FileMgr._delete now uses recursion itself instead of calling rmtree. Add method FileMgr.copy