### PR TITLE
Fix issues caused by switching signal to g_idle_add_once calls. close…

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -518,7 +518,7 @@ class BookC:
     """
 
     #the list of signals that BookC is allowed to send to the component views
-    book_tx_api = ['update', 'get_view', 'close', 'begin_edit_mode', 'begin_display_mode', 'save_title', 'save']
+    book_tx_api = ['update', 'get_view', 'close', 'begin_edit_mode', 'begin_display_mode', 'save_title']
     # the list of signals that the component views is allowed to send to BookC
     component_tx_api = ['save_button', 'cancel_button', 'edit_button', 'close']
 
@@ -601,8 +601,9 @@ class BookC:
     def save(self):
         """Coordinate the saving of the book with Book and the the VC classes"""
         book_data = BookData(self.book.playlist_data)
-        # notify the VC classes that they need to save
-        self.transmitter.send('save', book_data)
+        for track in self.playlist_vc.get_current_track_list():
+            book_data.track_list.append(track)
+        book_data.playlist_data.set_title(self.title_vc.get_title())
         self.book.save(book_data)
         # Tell the book that it is finished saving and can cleanup
         reloaded_book_data = self.book.book_data_load(self.book.playlist_data)

--- a/src/book_reader.py
+++ b/src/book_reader.py
@@ -298,4 +298,3 @@ class OpenBook:
 
     def close(self):
         self.transmitter.send('close')
-        del self._book, self._notebook_page, self.br_notebook_tab_vc, self.transmitter

--- a/src/gui/gtk/book_view.py
+++ b/src/gui/gtk/book_view.py
@@ -25,6 +25,7 @@ This module is responsible for displaying books in the view
 """
 from pathlib import Path
 import itertools
+from typing import Generator
 import gi
 gi.require_version("Gtk", "3.0") # pylint: disable=wrong-import-position
 from gi.repository import Gtk
@@ -115,7 +116,6 @@ class TitleVC:
         book_tx_signal.connect('begin_edit_mode', self.begin_edit_mode)
         book_tx_signal.connect('begin_display_mode', self.begin_display_mode)
         book_tx_signal.connect('update', self.update)
-        book_tx_signal.connect('save', self.save)
         # save a reference to the book model so TitleVC can get data when it needs to
         self.book = book_
         # create the Gtk view
@@ -148,9 +148,10 @@ class TitleVC:
         """relay the message to close the view"""
         self.title_v.close()
 
-    def save(self, book_data):
-        """Get the playlist title from the title_v model and save it to book_data."""
-        book_data.playlist_data.set_title(self.title_v.title_entry.get_text())
+    def get_title(self) -> str:
+        """Get the current playlist title text from the title_v model."""
+        return self.title_v.title_entry.get_text()
+
 
 class ControlBtnV:
     """display the control buttons"""
@@ -384,7 +385,6 @@ class PlaylistVC:
         # subscribe to the signals relevant to this class
         book_transmitter.connect('close', self.close)
         book_transmitter.connect('update', self.update)
-        book_transmitter.connect('save', self.save)
         book_transmitter.connect('begin_edit_mode', self.begin_edit_mode)
         book_transmitter.connect('begin_display_mode', self.begin_display_mode)
 
@@ -434,15 +434,17 @@ class PlaylistVC:
         """relay the message to close the view"""
         self.playlist_v.close()
 
-    def save(self, book_data) -> None:
+    def get_current_track_list(self) -> Generator[playlist.Track, None, None]:
         """
-        Get Track objects represented by rows in the playlist_model and save them to the Book
+        Get Track objects represented by rows in the playlist_model and save them to a tracklist
+
+        Note: Typehint formatting for generators is Generator[yield_type, send_type, return_type]
         """
         while True:
             track = self.playlist_model.pop()
             if track is None:
                 break
-            book_data.track_list.append(track)
+            yield track
 
     def get_toggled_tv_col_direction(self, tree_view_column):
         """Get the current sort order (Gtk.SortType) for a tree view column and return the opposite Gtk.SortType"""


### PR DESCRIPTION
… #592

book_reader.py:
OpenBook.close: remove line that called del on the instance attributes. BookReader needed to access those attributes after that had been del'd. Before it didn't matter b/c the 'close' signal that OpenBook sent happened sequentially before the call to del.

book_view.py:
TitleVC.save and PlaylistVC.save are replaced with getter functions. Both classes no longer subscribe to a save signal.

book.py
remove 'save' from BookC.book_tx_api.
BookC.save stops passing a BookData object additional arg with a 'save' signal. It was doing that in the hopes that the BookData would get populated by the subscribers. Instead it now directly calls getters from the would be subscribers.