### PR TITLE
switch to populating PlayerButtonInfoVC's stream info dialog on deman…

### DIFF
--- a/src/gui/gtk/player_view.py
+++ b/src/gui/gtk/player_view.py
@@ -658,17 +658,25 @@ class PlayerButtonInfoVC:
     def _on_info_button_released(self, *_) -> None:
         """
         Callback for when the gtk button is released.
+        Prepare and display the stream info dialog.
         """
         self._logger.debug('on_button_released')
+        try:
+            buffer_text = self._player.player_adapter.query_stream_info()
+        except player.GstPlayerError:
+            buffer_text = 'Failed to query stream info'
+            self._logger.error(buffer_text)
+            buffer_text += '\nTry again or perhaps try pressing play first'
+
+        self._info_dialog_text_buffer.set_text(buffer_text)
         self._info_dialog.show_all()
         self._info_dialog.run()
 
-    def _activate(self, stream_data: player.StreamData) -> None:
+    def _activate(self, _stream_data: player.StreamData) -> None:
         """
         Set the button to active state
         """
         self._logger.debug('activate')
-        self._info_dialog_text_buffer.set_text(stream_data.stream_info)
         self._view.set_sensitive(True)
 
     def _deactivate(self) -> None:

--- a/src/player.py
+++ b/src/player.py
@@ -510,7 +510,6 @@ class Player:  # pylint: disable=unused-argument
         """
         self.logger.debug('_on_stream_loaded')
         self.stream_data.duration = self.player_adapter.query_duration()
-        self.stream_data.stream_info = self.player_adapter.query_stream_info()
         self.stream_data.volume = self.player_adapter.query_volume()
         self.transmitter.send('stream_updated', self.stream_data)
 


### PR DESCRIPTION
…d. close #619

player.py:
Remove call to .player_adapter.query_stream_info() inside Player._on_stream_loaded

player_view.py:
Populate the dialog's text_buffer in the
PlayerButtonInfoVC._on_info_button_released.